### PR TITLE
マイグレーションファイルの記述をrubocopに合わせて変更

### DIFF
--- a/db/migrate/20230118111633_add_details_to_users.rb
+++ b/db/migrate/20230118111633_add_details_to_users.rb
@@ -2,8 +2,10 @@
 
 class AddDetailsToUsers < ActiveRecord::Migration[7.0]
   def change
-    add_column :users, :failed_attempts, :integer, default: 0, null: false, after: :remember_created_at
-    add_column :users, :unlock_token, :string, after: :failed_attempts
-    add_column :users, :locked_at, :datetime, after: :unlock_token
+    change_table :users, bulk: true do |t|
+      t.integer :failed_attempts, default: 0, null: false, after: :remember_created_at
+      t.string :unlock_token, after: :failed_attempts
+      t.datetime :locked_at, after: :unlock_token
+    end
   end
 end


### PR DESCRIPTION
## PRの目的
マイグレーションファイルの記述をrubocopに合わせて変更しました。

## 重点的に見て欲しいポイント
なし
