### PR TITLE
Docker ImageをAlpineに変更する

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,19 @@
-FROM ruby:3.2.2
-RUN apt-get update -qq && apt-get install -y nodejs yarnpkg chromium chromium-driver vim
-RUN ln -s /usr/bin/yarnpkg /usr/bin/yarn
-RUN mkdir /app
+FROM ruby:3.2.2-alpine3.18
+
 WORKDIR /app
 COPY Gemfile /app/Gemfile
 COPY Gemfile.lock /app/Gemfile.lock
-RUN bundle install
-COPY . /app
 
-# Add a script to be executed every time the container starts.
+RUN apk update && \
+    apk upgrade && \
+    apk add --no-cache linux-headers libxml2-dev make gcc libc-dev nodejs yarn tzdata bash mysql-dev && \
+    apk add --no-cache -t .build-packages --no-cache build-base curl-dev mysql-client && \
+    bundle install && \
+    apk del --purge .build-packages
+
 COPY entrypoint.sh /usr/bin/
 RUN chmod +x /usr/bin/entrypoint.sh
 ENTRYPOINT ["entrypoint.sh"]
 EXPOSE 3000
 
-# Start the main process.
 CMD ["rails", "server", "-b", "0.0.0.0"]


### PR DESCRIPTION
## PRの目的
DockerのベースイメージをAlpineイメージに変更しました。

軽量化されることでビルド時間が短縮されることを期待しています。

## 重点的に見て欲しいポイント
```
# Alpineイメージ変更前

% docker images         
REPOSITORY                    TAG       IMAGE ID       CREATED         SIZE
contents_management_app-web   latest    dadc1043b2eb   3 minutes ago   2.39GB
mysql                         8.0.32    412b8cc72e4a   4 months ago    531MB
```

```
# Alpineイメージ変更後

% docker images
REPOSITORY                    TAG       IMAGE ID       CREATED         SIZE
contents_management_app-web   latest    e81c9b7e2994   3 minutes ago   468MB
mysql                         8.0.32    412b8cc72e4a   4 months ago    531MB
```

## 対象のissues
なし

## 備考
特になし。