### PR TITLE
ログ一覧にユーザ削除のログ表示を追加

### DIFF
--- a/app/controllers/logs_controller.rb
+++ b/app/controllers/logs_controller.rb
@@ -2,6 +2,10 @@
 
 class LogsController < ApplicationController
   def index
-    @organizations = Organization.unscope(:where).where.not(discarded_at: nil)
+    @organization_logs = Organization.unscope(:where).where.not(discarded_at: nil)
+    @user_logs = User.unscope(:where).where.not(discarded_at: nil)
+    
+    # 表示させるデータをソートできるように以下で配列を作成
+    @logs = (@organization_logs + @user_logs).sort_by(&:discarded_at).reverse
   end
 end

--- a/app/views/logs/index.html.erb
+++ b/app/views/logs/index.html.erb
@@ -9,10 +9,11 @@
     </tr>
   </thead>
   <tbody>
+    <%# 組織名とユーザ名がどちらも name カラムのため log.name としている %>
     <% @logs.each do |log| %>
       <tr>
         <td><%= "#{log.is_a?(Organization) ? '組織' : log.is_a?(User) ? 'ユーザ' : 'Unknown'} を削除しました" %></td>
-        <td><%= log.name %></td>
+        <td><%= log.name %></td> 
         <td><%= l log.discarded_at, format: :default %></td>
       </tr>
     <% end %>

--- a/app/views/logs/index.html.erb
+++ b/app/views/logs/index.html.erb
@@ -12,8 +12,8 @@
     <%# 組織名とユーザ名がどちらも name カラムのため log.name としている %>
     <% @logs.each do |log| %>
       <tr>
-        <td><%= "#{log.is_a?(Organization) ? '組織' : log.is_a?(User) ? 'ユーザ' : 'Unknown'} を削除しました" %></td>
-        <td><%= log.name %></td> 
+        <td><%= "#{(log.is_a?(Organization)) ? '組織' : (log.is_a?(User)) ? 'ユーザ' : 'Unknown'} を削除しました" %></td>
+        <td><%= log.name %></td>
         <td><%= l log.discarded_at, format: :default %></td>
       </tr>
     <% end %>

--- a/app/views/logs/index.html.erb
+++ b/app/views/logs/index.html.erb
@@ -1,17 +1,19 @@
-<h3>操作ログ</h3>
+<h3>ログ</h3>
 
 <table border='1' class="table overflow-scroll">
   <thead>
     <tr>
-      <th>組織名</th>
+      <th>操作</th>
+      <th>対象名</th>
       <th>削除日時</th>
     </tr>
   </thead>
   <tbody>
-    <% @organizations.find_each do |organization| %>
+    <% @logs.each do |log| %>
       <tr>
-        <td><%= organization.name %></td>
-        <td><%= l organization.discarded_at, format: :default %></td>
+        <td><%= "#{log.is_a?(Organization) ? '組織' : log.is_a?(User) ? 'ユーザ' : 'Unknown'} を削除しました" %></td>
+        <td><%= log.name %></td>
+        <td><%= l log.discarded_at, format: :default %></td>
       </tr>
     <% end %>
   </tbody>


### PR DESCRIPTION
## PRの目的
・ログ一覧にユーザ削除のログ表示を追加
・既存の組織削除のログと合わせてソート表示されるように修正
## 重点的に見て欲しいポイント


## 対象のissues


## 備考
「ユーザ一覧の論理削除ボタンと挙動を追加」のマージが先になります