### PR TITLE
RubocopにおいてCreateTableWithTimestampsの警告を無効に設定

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -44,5 +44,4 @@ Metrics/BlockLength:
     - config/routes.rb
 
 Rails/CreateTableWithTimestamps:
-  Exclude:
-    - db/migrate/*.rb
+  Enabled: false


### PR DESCRIPTION
## PRの目的
タイムスタンプ関連の警告が出ない様に設定を変更しました。

## 重点的に見て欲しいポイント


## 対象のissues
https://github.com/hiroaki514/contents_management_app/issues/208

## 備考
