### PR TITLE
【機能追加】作成ログと削除ログをログ画面に表示する(ユーザ、組織含む)

### DIFF
--- a/app/controllers/logs_controller.rb
+++ b/app/controllers/logs_controller.rb
@@ -2,10 +2,7 @@
 
 class LogsController < ApplicationController
   before_action :fetch_log_types, only: %i[index]
-  def index
-    # 表示用に @logs 内のデータをソートする
-    @logs = @logs.sort_by(&:discarded_at).reverse
-  end
+  def index; end
 
   private
 

--- a/app/controllers/logs_controller.rb
+++ b/app/controllers/logs_controller.rb
@@ -13,25 +13,26 @@ class LogsController < ApplicationController
     # case でログのタイプ毎に分岐
     @logs = case params[:log_type]
             when 'organization'
-              # fetch_logs_with_created_user_id(Organization) +
-              # fetch_logs_with_discarded_at(Organization) +
-              # fetch_logs_with_created_at(Organization)
+              organization_logs
             when 'user'
-              fetch_logs_with_created_user_id(User) +
-              fetch_logs_with_discarded_at(User) +
-              fetch_logs_with_created_at(User)
+              user_logs
             else
               all_logs
             end
   end
 
   def all_logs
-    # fetch_logs_with_created_user_id(Organization) +
-    # fetch_logs_with_discarded_at(Organization) +
-    # fetch_logs_with_created_at(Organization)
-    fetch_logs_with_created_user_id(User) +
+    (user_logs + organization_logs)
+  end
+
+  def user_logs
     fetch_logs_with_discarded_at(User) +
-    fetch_logs_with_created_at(User)
+    fetch_logs_with_created_user_id(User)
+  end
+
+  def organization_logs
+    fetch_logs_with_discarded_at(Organization) +
+    fetch_logs_with_created_user_id(Organization)
   end
 
   # モデルに記述したデフォルトスコープを無視して discarded_at が nil でないものを取得
@@ -43,8 +44,5 @@ class LogsController < ApplicationController
     model.where.not(created_user_id: nil)
   end
 
-  def fetch_logs_with_created_at(model)
-    model.where.not(created_at: nil)
-  end
 
 end

--- a/app/controllers/logs_controller.rb
+++ b/app/controllers/logs_controller.rb
@@ -13,21 +13,38 @@ class LogsController < ApplicationController
     # case でログのタイプ毎に分岐
     @logs = case params[:log_type]
             when 'organization'
-              fetch_logs(Organization)
+              # fetch_logs_with_created_user_id(Organization) +
+              # fetch_logs_with_discarded_at(Organization) +
+              # fetch_logs_with_created_at(Organization)
             when 'user'
-              fetch_logs(User)
+              fetch_logs_with_created_user_id(User) +
+              fetch_logs_with_discarded_at(User) +
+              fetch_logs_with_created_at(User)
             else
               all_logs
             end
   end
 
   def all_logs
-    Organization.unscope(:where).where.not(discarded_at: nil) +
-      User.unscope(:where).where.not(discarded_at: nil)
+    # fetch_logs_with_created_user_id(Organization) +
+    # fetch_logs_with_discarded_at(Organization) +
+    # fetch_logs_with_created_at(Organization)
+    fetch_logs_with_created_user_id(User) +
+    fetch_logs_with_discarded_at(User) +
+    fetch_logs_with_created_at(User)
   end
 
   # モデルに記述したデフォルトスコープを無視して discarded_at が nil でないものを取得
-  def fetch_logs(model)
+  def fetch_logs_with_discarded_at(model)
     model.unscope(:where).where.not(discarded_at: nil)
   end
+
+  def fetch_logs_with_created_user_id(model)
+    model.where.not(created_user_id: nil)
+  end
+
+  def fetch_logs_with_created_at(model)
+    model.where.not(created_at: nil)
+  end
+
 end

--- a/app/controllers/members_controller.rb
+++ b/app/controllers/members_controller.rb
@@ -21,13 +21,16 @@ class MembersController < ApplicationController
 
   def create
     @user = User.new(user_params)
+
     if @user.save
-      redirect_to members_path
+      @user.update(created_user_id: current_user.id)
       flash[:success] = 'ユーザを登録しました'
+      redirect_to members_path
     else
       render :new
     end
   end
+
 
   def update
     if @user.update(user_params)

--- a/app/controllers/members_controller.rb
+++ b/app/controllers/members_controller.rb
@@ -32,13 +32,13 @@ class MembersController < ApplicationController
   end
 
   def update
-    if @user.update(user_params)
-      redirect_to members_path
+    if @user.update(user_params.merge(updated_user_id: current_user.id))
       flash[:success] = 'ユーザを更新しました'
+      redirect_to members_path
     else
       render :edit
     end
-  end
+  end 
 
   def destroy
     if @user.update(discarded_at: Time.zone.now)

--- a/app/controllers/members_controller.rb
+++ b/app/controllers/members_controller.rb
@@ -31,7 +31,6 @@ class MembersController < ApplicationController
     end
   end
 
-
   def update
     if @user.update(user_params)
       redirect_to members_path

--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -29,9 +29,9 @@ class OrganizationsController < ApplicationController
   end
 
   def update
-    if @organization.update(organization_params)
-      redirect_to organizations_path
+    if @organization.update(organization_params.merge(updated_user_id: current_user.id))
       flash[:success] = '組織名を更新しました'
+      redirect_to organizations_path
     else
       render :edit
     end

--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -17,13 +17,14 @@ class OrganizationsController < ApplicationController
 
   def create
     @organization = Organization.new(organization_params)
-    if @organization.valid?
-      @organization.save
-      redirect_to organizations_path
+
+    if @organization.save
+      @organization.update(created_user_id: current_user.id)
       flash[:success] = '組織を登録しました'
+      redirect_to organizations_path
     else
-      render :new
       flash.now[:alert] = '組織の登録に失敗しました'
+      render :new
     end
   end
 

--- a/app/views/logs/index.html.erb
+++ b/app/views/logs/index.html.erb
@@ -10,14 +10,17 @@
     <tr>
       <th>操作</th>
       <th>対象名</th>
-      <th>削除日時</th>
+      <th>実施日時</th>
     </tr>
   </thead>
   <tbody>
     <% @logs.each do |log| %>
       <% if params[:log_type].blank? || params[:log_type] == 'all' || (params[:log_type] == 'organization' && log.is_a?(Organization)) || (params[:log_type] == 'user' && log.is_a?(User)) %>
         <tr>
-          <td><%= "#{log.is_a?(Organization) ? '組織' : log.is_a?(User) ? 'ユーザ' : 'Unknown'} を削除しました" %></td>
+          <td>
+            <%= "#{log.is_a?(Organization) ? '組織' : log.is_a?(User) ? 'ユーザ' : 'Unknown'} 
+            #{log.discarded_at.present? ? 'を削除しました' : (log.created_user_id.present? ? 'を作成しました' : '')}" %>
+          </td>
           <%# 組織名とユーザ名がどちらも name カラムのため log.name としているので要修正 %>
           <td><%= log.name %></td>
           <td><%= l log.discarded_at, format: :default %></td>

--- a/db/migrate/20231002130044_add_discarded_at_to_organization.rb
+++ b/db/migrate/20231002130044_add_discarded_at_to_organization.rb
@@ -2,6 +2,6 @@
 
 class AddDiscardedAtToOrganization < ActiveRecord::Migration[7.0]
   def change
-    add_column :organizations, :discarded_at, :datetime, after: :name, comment: '削除日時'
+    add_column :organizations, :discarded_at, :datetime, after: :created_at, comment: '削除日時'
   end
 end

--- a/db/migrate/20231127081840_add_created_user_id_to_organizations.rb
+++ b/db/migrate/20231127081840_add_created_user_id_to_organizations.rb
@@ -1,0 +1,5 @@
+class AddCreatedUserIdToOrganizations < ActiveRecord::Migration[7.0]
+  def change
+    add_column :organizations, :created_user_id, :integer,  after: :name, comment: '作成者'
+  end
+end

--- a/db/migrate/20231127084710_add_updated_user_id_to_organizations.rb
+++ b/db/migrate/20231127084710_add_updated_user_id_to_organizations.rb
@@ -1,0 +1,5 @@
+class AddUpdatedUserIdToOrganizations < ActiveRecord::Migration[7.0]
+  def change
+    add_column :organizations, :updated_user_id, :integer,  after: :created_user_id, comment: '更新者'
+  end
+end

--- a/db/migrate/20231127085106_add_updated_user_id_to_users.rb
+++ b/db/migrate/20231127085106_add_updated_user_id_to_users.rb
@@ -1,0 +1,5 @@
+class AddUpdatedUserIdToUsers < ActiveRecord::Migration[7.0]
+  def change
+    add_column :users, :updated_user_id, :integer, after: :created_user_id, comment: '更新者'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_11_15_131224) do
+ActiveRecord::Schema[7.0].define(version: 2023_11_27_081840) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -41,8 +41,9 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_15_131224) do
 
   create_table "organizations", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name", null: false, comment: "組織名"
-    t.datetime "discarded_at", comment: "削除日時"
+    t.integer "created_user_id", comment: "作成者"
     t.datetime "created_at", null: false
+    t.datetime "discarded_at", comment: "削除日時"
     t.datetime "updated_at", null: false
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_11_27_081840) do
+ActiveRecord::Schema[7.0].define(version: 2023_11_27_085106) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -42,6 +42,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_27_081840) do
   create_table "organizations", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name", null: false, comment: "組織名"
     t.integer "created_user_id", comment: "作成者"
+    t.integer "updated_user_id", comment: "更新者"
     t.datetime "created_at", null: false
     t.datetime "discarded_at", comment: "削除日時"
     t.datetime "updated_at", null: false
@@ -67,6 +68,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_27_081840) do
     t.string "unlock_token"
     t.datetime "locked_at", precision: nil
     t.integer "created_user_id", comment: "作成者"
+    t.integer "updated_user_id", comment: "更新者"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.datetime "discarded_at", comment: "削除日時"


### PR DESCRIPTION
## PRの目的
ログ画面に以下の情報が表示されるようにします。
・ユーザの作成ログ
・ユーザの削除ログ


※問題点
1.操作項目において、"ユーザor組織"+"を作成or削除しました"の表示分け(今後いろいろなログを表示させるにあたり、複数判
定できるようにしておきたい)

2.現在「削除日時」項目がある部分を「実施日時」に変更し、created_atかdiscarded_atの日時情報を表示したい

3.上記を含めるにあたり、コントローラーの記述が難しい


## 重点的に見て欲しいポイント


## 対象のissues


## 備考
