### PR TITLE
【修正】組織一覧ページにページネーションが記述されていなかったため修正

### DIFF
--- a/app/views/organizations/index.html.erb
+++ b/app/views/organizations/index.html.erb
@@ -30,3 +30,4 @@
   </tbody>
 </table>
 
+<%= paginate @organizations %>


### PR DESCRIPTION
## PRの目的
ページネーション用の記述が記述されておらず10件以降が見れない状態だったため修正を行いました。

## 重点的に見て欲しいポイント


## 対象のissues


## 備考
